### PR TITLE
fix: mobile lighthouse accessibility

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -40,10 +40,13 @@ function ready() {
 
     document.getElementById('hamburger-menu-toggle').addEventListener('click', () => {
         const hamburgerMenu = document.getElementsByClassName('nav-hamburger-list')[0]
+        const hamburgerMenuToggleTarget = document.getElementById("hamburger-menu-toggle-target")
         if (hamburgerMenu.classList.contains('visibility-hidden')) {
             hamburgerMenu.classList.remove('visibility-hidden');
+            hamburgerMenuToggleTarget.setAttribute("aria-checked", "true");
         } else {
             hamburgerMenu.classList.add('visibility-hidden');
+            hamburgerMenuToggleTarget.setAttribute("aria-checked", "false");
         }
     })
 }

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,7 +32,7 @@
 
             <div class="nav-link" id="hamburger-menu-toggle">
                 <span class="sr-only hamburger-menu-toggle-screen-reader-target">menu</span>
-                <a aria-labelledby="hamburger-menu-toggle" role="switch">
+                <a aria-checked="false" aria-labelledby="hamburger-menu-toggle" id="hamburger-menu-toggle-target" role="switch">
                     <span data-feather="menu"></span>
                 </a>
             </div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,7 +32,7 @@
 
             <div class="nav-link" id="hamburger-menu-toggle">
                 <span class="sr-only hamburger-menu-toggle-screen-reader-target">menu</span>
-                <a role="switch">
+                <a aria-labelledby="hamburger-menu-toggle" role="switch">
                     <span data-feather="menu"></span>
                 </a>
             </div>


### PR DESCRIPTION
Code is messy, but works.

### Mobile full run

Ignore emulated performance :roll_eyes:

![image](https://github.com/user-attachments/assets/1636d788-99d6-4896-bd6d-9955dd00a297)

### Desktop full run

![image](https://github.com/user-attachments/assets/ff05f485-7435-4038-b3f4-f915dd9070ce)
