### PR TITLE
Markdownify titles

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     {{- $avatarImgSrc := .Site.Params.AvatarURL -}}
-    {{- if and (isset site.Params "avatarURL") (not (hasPrefix $avatarImgSrc "http")) -}}
+    {{- if and (isset .Site.Params "avatarURL") (not (hasPrefix $avatarImgSrc "http")) -}}
         {{- $avatarImgSrc = (urls.JoinPath $.Site.BaseURL ($.Site.Params.AvatarURL | default "")) -}}
     {{- end -}}
     {{- .Scratch.Set "avatarImgSrc" $avatarImgSrc -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
         }
     </style>
 
-    {{ $title := (cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title) | default .Site.Title }}
+    {{ $title := .Title | markdownify | default .Site.Title }}
     {{ $description := ((.Description | default (.Summary | default .Content) | default .Site.Params.Description) | plainify | truncate 160) }}
     {{ $image := .Params.image | default (.Scratch.Get "avatarImgSrc") }}
     {{ $siteKeywords := .Site.Params.MetaKeywords | default (slice) }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
         }
     </style>
 
-    {{ $title := .Title | default .Site.Title }}
+    {{ $title := (cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title) | default .Site.Title }}
     {{ $description := ((.Description | default (.Summary | default .Content) | default .Site.Params.Description) | plainify | truncate 160) }}
     {{ $image := .Params.image | default (.Scratch.Get "avatarImgSrc") }}
     {{ $siteKeywords := .Site.Params.MetaKeywords | default (slice) }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,7 +8,7 @@
         }
     </style>
 
-    {{ $title := (cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title) | default .Site.Title }}
+    {{ $title := (cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title) | default .Site.Title }}
     {{ $description := ((.Description | default (.Summary | default .Content) | default .Site.Params.Description) | plainify | truncate 160) }}
     {{ $image := .Params.image | default (.Scratch.Get "avatarImgSrc") }}
     {{ $siteKeywords := .Site.Params.MetaKeywords | default (slice) }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,7 @@
         {{ end }}
 
         <div class="nav-title">
-            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
+            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</a>
         </div>
 
         <div class="nav-links">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,7 @@
         {{ end }}
 
         <div class="nav-title">
-            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</a>
+            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ .Title | markdownify }}</a>
         </div>
 
         <div class="nav-links">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,7 +10,7 @@
         {{ end }}
 
         <div class="nav-title">
-            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</a>
+            <a class="nav-brand" href="{{ .Site.BaseURL }}">{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</a>
         </div>
 
         <div class="nav-links">

--- a/layouts/partials/list-posts.html
+++ b/layouts/partials/list-posts.html
@@ -1,5 +1,5 @@
 <div class="post-title">
-     <a href="{{ .Permalink }}" class="post-link">{{ .Title }}</a>
+     <a href="{{ .Permalink }}" class="post-link">{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</a>
      {{/* Decide to display the date based on the tags */}}
      {{ $displayDate := true }}
      {{ $tagsHidePostDate := or .Site.Params.Hidden.TagsPostDate slice }}

--- a/layouts/partials/list-posts.html
+++ b/layouts/partials/list-posts.html
@@ -1,5 +1,5 @@
 <div class="post-title">
-     <a href="{{ .Permalink }}" class="post-link">{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</a>
+     <a href="{{ .Permalink }}" class="post-link">{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</a>
      {{/* Decide to display the date based on the tags */}}
      {{ $displayDate := true }}
      {{ $tagsHidePostDate := or .Site.Params.Hidden.TagsPostDate slice }}

--- a/layouts/partials/list-posts.html
+++ b/layouts/partials/list-posts.html
@@ -1,5 +1,5 @@
 <div class="post-title">
-     <a href="{{ .Permalink }}" class="post-link">{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</a>
+     <a href="{{ .Permalink }}" class="post-link">{{ .Title | markdownify }}</a>
      {{/* Decide to display the date based on the tags */}}
      {{ $displayDate := true }}
      {{ $tagsHidePostDate := or .Site.Params.Hidden.TagsPostDate slice }}

--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -1,7 +1,7 @@
 <div class="post container">
 
     <div class="post-header-section">
-        <h1>{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</h1>
+        <h1>{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</h1>
     </div>
 
     <div class="post-content">

--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -1,7 +1,7 @@
 <div class="post container">
 
     <div class="post-header-section">
-        <h1>{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</h1>
+        <h1>{{ .Title | markdownify }}</h1>
     </div>
 
     <div class="post-content">

--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -1,7 +1,7 @@
 <div class="post container">
 
     <div class="post-header-section">
-        <h1>{{ .Title }}</h1>
+        <h1>{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</h1>
     </div>
 
     <div class="post-content">

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,6 +1,6 @@
 <div class="post container">
     <div class="post-header-section">
-        <h1>{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</h1>
+        <h1>{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</h1>
 
         {{/* Determine whether to display the date & description based on tags */}}
 

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,6 +1,6 @@
 <div class="post container">
     <div class="post-header-section">
-        <h1>{{ .Title }}</h1>
+        <h1>{{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}</h1>
 
         {{/* Determine whether to display the date & description based on tags */}}
 

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,6 +1,6 @@
 <div class="post container">
     <div class="post-header-section">
-        <h1>{{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}</h1>
+        <h1>{{ .Title | markdownify }}</h1>
 
         {{/* Determine whether to display the date & description based on tags */}}
 

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -4,7 +4,7 @@
         <a href="{{ .RelPermalink }}">
             &#8592;
             {{ i18n "previous" }}:
-            {{ .Title }}
+            {{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}
         </a>
     </p>
     <p class="prev-post-date">
@@ -18,7 +18,7 @@
     <p>
         <a href="{{ .RelPermalink }}">
             {{ i18n "next" }}:
-            {{ .Title }}
+            {{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}
             &#8594;
         </a>
     </p>

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -4,7 +4,7 @@
         <a href="{{ .RelPermalink }}">
             &#8592;
             {{ i18n "previous" }}:
-            {{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}
+            {{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}
         </a>
     </p>
     <p class="prev-post-date">
@@ -18,7 +18,7 @@
     <p>
         <a href="{{ .RelPermalink }}">
             {{ i18n "next" }}:
-            {{ cond .Site.Params.markdownifyTitles (.Title | markdownify) .Title }}
+            {{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}
             &#8594;
         </a>
     </p>

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -4,7 +4,7 @@
         <a href="{{ .RelPermalink }}">
             &#8592;
             {{ i18n "previous" }}:
-            {{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}
+            {{ .Title | markdownify }}
         </a>
     </p>
     <p class="prev-post-date">
@@ -18,7 +18,7 @@
     <p>
         <a href="{{ .RelPermalink }}">
             {{ i18n "next" }}:
-            {{ cond (isset .Site.Params "markdownifytitles") (.Title | markdownify) .Title }}
+            {{ .Title | markdownify }}
             &#8594;
         </a>
     </p>


### PR DESCRIPTION
I noticed that some of my posts have ' in their titles which don't get properly converted into &rsquo; HTML smart quotes, so I passed all occurrences of `.Title` through `markdownify` to fix that.