### PR TITLE
fix: handle missing date format fallback

### DIFF
--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -25,7 +25,7 @@
 
 	{{ if $displayDate }}
           <p class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
-           {{ if lt .Date .Lastmod }} | Updated {{ dateFormat .Site.Params.dateFormat .Lastmod }}{{ end }}
+           {{ if lt .Date .Lastmod }} | Updated {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Lastmod }}{{ end }}
           </p>
 	{{ end }}
 


### PR DESCRIPTION
The user should not be expected to add `Date format` in config, if it is not added, it should fallback to default