### PR TITLE
docs: remove dateFormat warnings

### DIFF
--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -366,7 +366,7 @@ Will produce this footer:
 
 `copyright` can include [Markdown syntax](https://www.markdownguide.org/tools/hugo/). This is best used for including hyperlinks, emoji, or text formatting.
 
-The years of `.Date` and `.Lastmod` are used to create a date range for your copyrighted material. [dateFormat](/posts/theme-documentation-basics/#date-format) **must** be set in `config.toml` if `.Lastmod` is present in any front matter.
+The years of `.Date` and `.Lastmod` are used to create a date range for your copyrighted material.
 
 ## Minification
 

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -168,8 +168,6 @@ See this sample `config.toml`, which uses Gokarna's default values, and [example
   customHeadHTML = ""
 
   # Configure how post dates are displayed
-  # dateFormat must be set if lastmod is declared in front matter, or
-  # enableGitInfo is true
   dateFormat = "January 2, 2006"
   
   # Home page meta description
@@ -243,8 +241,6 @@ Examples are available in the [advanced documentation](/posts/theme-documentatio
 ### Date format 
 
 [Configure how posts date are displayed](https://gohugo.io/functions/time/format/), using [date strings](https://pkg.go.dev/time#pkg-constants).
-
-dateFormat **must be set** if [`enableGitInfo`](https://gohugo.io/methods/page/gitinfo/#prerequisites) is `true`, or [`.Lastmod`](https://gohugo.io/methods/page/lastmod/) is present in any front matter.
 
 ```toml 
 [params]


### PR DESCRIPTION
#291 fixed the breakages present when the (removed) conditions were not met