### PR TITLE
docs(basics): update fontSize

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -297,11 +297,11 @@ Favicons can be generated using services such as [favicon.io](https://favicon.io
 
 ### Font size
 
-Set the main font-size for the content. Default is `17.5px`.
+Set the content [`font-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size).
 
 ```toml
 [params]
-  fontSize = "20px"
+  fontSize = "17.5px"
 ```
 
 ### Footer

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -227,15 +227,6 @@ Set the avatar's size as: `size-xs`, `size-s`, `size-m`, `size-l`, or `size-xl`.
   avatarSize = "size-m"
 ```
 
-### Font size
-
-Set the main font-size for the content. Default is `17.5px`.
-
-```toml
-[params]
-  fontSize = "20px"
-```
-
 ### Custom Head HTML
 
 Add arbitrary HTML code to the [`<head>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head).
@@ -303,6 +294,15 @@ Place favicons into the `static/` directory. The following files are supported:
 - `android-chrome-512x512.png` (512x512)
 
 Favicons can be generated using services such as [favicon.io](https://favicon.io), or [realfavicongenerator.net](https://realfavicongenerator.net/).
+
+### Font size
+
+Set the main font-size for the content. Default is `17.5px`.
+
+```toml
+[params]
+  fontSize = "20px"
+```
 
 ### Footer
 


### PR DESCRIPTION
Update the docs for #295 to follow the patterns established in #243:

- List the **Font size** heading alphabetically
- Add link to explain the `font-size` CSS property
- Use default value in the code snippet

![image](https://github.com/user-attachments/assets/621dd63f-cc24-4f47-8492-b1b4c75088a3)

@526avijitgupta @yashmehrotra 