### PR TITLE
feat(post): add .ReadingTime

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -328,6 +328,15 @@ If any post front matter contains `weight`, the posts will not appear by Date. S
   togglePreviousAndNextButtons = "false"
 ```
 
+### Reading time
+
+Display a post's [estimated reading time](https://gohugo.io/methods/page/readingtime/) in minutes.
+
+```toml
+[params]
+  displayReadingTime = false
+```
+
 ### robots.txt
 
 [Automatically generate](https://gohugo.io/templates/robots/) a `robots.txt` file, used to ['manage crawler traffic to your site'](https://developers.google.com/search/docs/crawling-indexing/robots/intro).

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -24,8 +24,12 @@
 	{{ end }}
 
 	{{ if $displayDate }}
-          <p class="post-date">{{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
-           {{ if lt .Date .Lastmod }} | Updated {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Lastmod }}{{ end }}
+          <p class="post-date">
+              {{ .ReadingTime }} min read | {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date }}
+
+              {{ if lt .Date .Lastmod }}
+                  | Updated {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Lastmod }}
+              {{ end }}
           </p>
 	{{ end }}
 

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -25,7 +25,11 @@
 
 	{{ if $displayDate }}
           <p class="post-date">
-              {{ .ReadingTime }} min read | {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date }}
+              {{ if (eq .Site.Params.DisplayReadingTime true) }}
+                  {{ .ReadingTime }} min read |
+              {{ end }}
+
+              {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date }}
 
               {{ if lt .Date .Lastmod }}
                   | Updated {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Lastmod }}


### PR DESCRIPTION
display estimated reading time before date (like Medium.com)

https://gohugo.io/methods/page/readingtime/