### PR TITLE
refactor(index): support _index.md

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -444,7 +444,7 @@ table td {
   transition: fill 0.15s ease;
 }
 
-.markdown-content {
+.home-content {
   line-height: 1.25;
   width: 80%;
   margin: 0 auto;
@@ -593,7 +593,7 @@ table td {
     width: auto;
   }
 
-  .markdown-content, .home-posts {
+  .home-content, .home-posts {
     width: auto;
     margin: 0;
   }

--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -84,7 +84,8 @@ The `weight` attribute can be added in the markdown metadata for `post` types. W
 ### About description text
 
 In extension to the basic configuration with the `description` field, it's also possible to write the about section using markdown.
-Create a file called `index-about.md` in the `content` directory and write your content there.
+
+Create a file called `_index.md` in the `content` directory and write your content there.
 
 > **Attention**: Don't use frontmatter in this file. It would also render it.
 

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -258,7 +258,7 @@ Examples are available in the [advanced documentation](/posts/theme-documentatio
 
 ### Display content on the home page
 
-Markdown content in `content/index-about.md` will be rendered on the home page, below the social icons.
+Markdown content in `content/_index.md` will be rendered on the home page, below the social icons.
 
 ### Display posts on the home page
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,10 +29,13 @@
 </div>
 {{ end }}
 
-{{ if os.FileExists "index-about.md" }}
-<div class="markdown-content">
-    {{ readFile "index-about.md" | markdownify }}
-</div>
+{{ if (or
+    (and (fileExists "content/_index.md") .Content)
+    (fileExists "content/index-about.md")) }}
+        <hr>
+        <section class="home-content">
+            {{ or .Content (readFile "index-about.md" | markdownify) }}
+        </section>
 {{ end }}
 
 {{ if isset .Site.Params "showpostsonhomepage" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,7 +32,6 @@
 {{ if (or
     (and (fileExists "content/_index.md") .Content)
     (fileExists "content/index-about.md")) }}
-        <hr>
         <section class="home-content">
             {{ or .Content (readFile "index-about.md" | markdownify) }}
         </section>


### PR DESCRIPTION
re-implement #119 - the Hugo way of displaying front matter - without breaking index-about.md (#179)

https://gohugo.io/content-management/organization/#index-pages-_indexmd

if _index.md exists (and has content), print it
else, if index-about.md exists (without checking for file contents), print it