### PR TITLE
fix(css): long footerText can overlap Markdown content

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -249,7 +249,7 @@ a:hover .feather-sun {
   margin-left: 30%;
   overflow: hidden;
   padding: 40px 0;
-  position: absolute;
+  position: relative;
   text-align: center;
   width: 40%;
 }


### PR DESCRIPTION
set position to a value other than absolute or fixed: https://developer.mozilla.org/en-US/docs/Web/CSS/position