### PR TITLE
Revert "fix(css): long footerText can overlap Markdown content"

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -249,7 +249,7 @@ a:hover .feather-sun {
   margin-left: 30%;
   overflow: hidden;
   padding: 40px 0;
-  position: relative;
+  position: absolute;
   text-align: center;
   width: 40%;
 }


### PR DESCRIPTION
Reverts gokarna-theme/gokarna-hugo#327