### PR TITLE
feat: add h1 param to front matter

### DIFF
--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -319,6 +319,26 @@ and the `metaKeywords` specified in the config.toml:
   metaKeywords = ["blog", "gokarna", "hugo"]
 ```
 
+## Page title and H1
+
+
+By default, Gokarna uses `.Title` for the `<title>` and `<h1>` elements, in addition to the OpenGraph (`og:title`) and Twitter (`twitter:title`) properties within `<meta>` elements.
+
+```yaml
+---
+title: "8 Facts About Me - #7 Will Shock You!"
+---
+```
+
+To define H1 separately from the page title, use the `h1` param in your front matter:
+
+```yaml
+---
+title: "8 Facts About Me - #7 Will Shock You!"
+h1: "8 Facts About Me"
+---
+```
+
 ## Hide tags, date or description of posts
 
 Tags can be used to categorize posts (e.g.: Project or Blog), and be hidden on

--- a/exampleSite/content/posts/theme-documentation-advanced.md
+++ b/exampleSite/content/posts/theme-documentation-advanced.md
@@ -321,7 +321,6 @@ and the `metaKeywords` specified in the config.toml:
 
 ## Page title and H1
 
-
 By default, Gokarna uses `.Title` for the `<title>` and `<h1>` elements, in addition to the OpenGraph (`og:title`) and Twitter (`twitter:title`) properties within `<meta>` elements.
 
 ```yaml

--- a/layouts/partials/page.html
+++ b/layouts/partials/page.html
@@ -1,7 +1,7 @@
 <div class="post container">
 
     <div class="post-header-section">
-        <h1>{{ .Title | markdownify }}</h1>
+        <h1>{{ or (.Params.H1 | markdownify) (.Title | markdownify) }}</h1>
     </div>
 
     <div class="post-content">

--- a/layouts/partials/post.html
+++ b/layouts/partials/post.html
@@ -1,6 +1,6 @@
 <div class="post container">
     <div class="post-header-section">
-        <h1>{{ .Title | markdownify }}</h1>
+        <h1>{{ or (.Params.H1 | markdownify) (.Title | markdownify) }}</h1>
 
         {{/* Determine whether to display the date & description based on tags */}}
 


### PR DESCRIPTION
allows H1 to be defined separately from the page title