### PR TITLE
Fix footer overlap issue on blog posts with navigation

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,7 +34,7 @@ body {
   margin-bottom: 170px;
 }
 
-body:has(.post-navigation) {
+body.blog-post.has-post-navigation {
   margin-bottom: 80px;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -640,6 +640,10 @@ table td {
   overflow: hidden;
 }
 
+.post-navigation {
+  padding: 40px 0;
+}
+
 .post-navigation::after {
   content: "";
   display: table;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -640,6 +640,12 @@ table td {
   overflow: hidden;
 }
 
+.post-navigation::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
 .prev-post {
   float: left;
   text-align: left;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -649,9 +649,9 @@ table td {
 }
 
 .post-navigation::after {
+  clear: both;
   content: "";
   display: table;
-  clear: both;
 }
 
 .prev-post {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -34,6 +34,10 @@ body {
   margin-bottom: 170px;
 }
 
+body:has(.post-navigation) {
+  margin-bottom: 80px;
+}
+
 b,
 strong {
   font-weight: bold;

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -1,4 +1,4 @@
-<div class="post-navigation">
+<nav aria-label="Post navigation" class="post-navigation">
     {{ with .PrevInSection }}
     <div class="prev-post">
         <p>
@@ -28,4 +28,4 @@
             </p>
     </div>
     {{ end }}
-</div>
+</nav>

--- a/layouts/partials/prev-next.html
+++ b/layouts/partials/prev-next.html
@@ -1,29 +1,31 @@
-{{ with .PrevInSection }}
-<div class="prev-post">
-    <p>
-        <a href="{{ .RelPermalink }}">
-            &#8592;
-            {{ i18n "previous" }}:
-            {{ .Title | markdownify }}
-        </a>
-    </p>
-    <p class="prev-post-date">
-        {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
-    </p>
-</div>
-{{ end }}
-
-{{ with .NextInSection }}
-<div class="next-post">
-    <p>
-        <a href="{{ .RelPermalink }}">
-            {{ i18n "next" }}:
-            {{ .Title | markdownify }}
-            &#8594;
-        </a>
-    </p>
-        <p class="next-post-date">
+<div class="post-navigation">
+    {{ with .PrevInSection }}
+    <div class="prev-post">
+        <p>
+            <a href="{{ .RelPermalink }}">
+                &#8592;
+                {{ i18n "previous" }}:
+                {{ .Title | markdownify }}
+            </a>
+        </p>
+        <p class="prev-post-date">
             {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
         </p>
+    </div>
+    {{ end }}
+
+    {{ with .NextInSection }}
+    <div class="next-post">
+        <p>
+            <a href="{{ .RelPermalink }}">
+                {{ i18n "next" }}:
+                {{ .Title | markdownify }}
+                &#8594;
+            </a>
+        </p>
+            <p class="next-post-date">
+                {{ dateFormat (or .Site.Params.dateFormat "January 2, 2006") .Date}}
+            </p>
+    </div>
+    {{ end }}
 </div>
-{{ end }}


### PR DESCRIPTION
Fixes a bug in which the footer was overlapping with the previous/next post navigation links on posts when only one navigation button was present (e.g., on the most recent post where no "next" button exists).

Changes:

- Wrapped the entirety of `prev-next.html` in a container, and added clearfix to the container to properly contain the floated elements.
- Reduced body margin on blog posts when post navigation is present. The global body's `margin-bottom: 170px;` was creating excessive space between the navigation and footer on blog posts. A targeted rule reduces this to `80px` to maintain consistent spacing while accounting for floated post navigation elements.
- Increased the space between post content and post navigation for visual consistency.