### PR TITLE
Open social media links on homepage in new tabs

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,7 @@
     <ul class="gk-social-icons-list">
         {{ range .Site.Params.SocialIcons }}
         <li class="gk-social-icon">
-            <a href="{{ .url }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} aria-label="Learn more on {{ .name }}">
+            <a href="{{ .url }}" target="_blank" rel="{{ if .rel }}{{ .rel }} {{ end }}noopener noreferrer" aria-label="Learn more on {{ .name }}">
                 <img class="svg-inject" src="{{ relURL "svg/icons/" }}{{ .name | lower }}.svg" alt="">
             </a>
         </li>


### PR DESCRIPTION
External social media links on the homepage open in new tabs.

- Added `target="_blank"` and `rel="noopener noreferrer"` to social media links while preserving custom `rel` attributes.