### PR TITLE
refactor: don't declare font-size in px

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -300,7 +300,7 @@ Note that '[defining font sizes in px is not accessible](https://developer.mozil
 
 ```toml
 [params]
-  fontSize = "1.094rem" # equal to 17.5px
+  fontSize = "1.1rem" # equal to 17.6px
 ```
 
 ### Footer

--- a/exampleSite/content/posts/theme-documentation-basics.md
+++ b/exampleSite/content/posts/theme-documentation-basics.md
@@ -296,9 +296,11 @@ Favicons can be generated using services such as [favicon.io](https://favicon.io
 
 Set the content [`font-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size).
 
+Note that '[defining font sizes in px is not accessible](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#pixels)'.
+
 ```toml
 [params]
-  fontSize = "17.5px"
+  fontSize = "1.094rem" # equal to 17.5px
 ```
 
 ### Footer

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
     <style>
         :root {
             --accent-color: {{ .Site.Params.AccentColor | default "#FF4D4D" }};
-            --font-size: {{ .Site.Params.FontSize | default "1.094rem" }};
+            --font-size: {{ .Site.Params.FontSize | default "1.1rem" }};
         }
     </style>
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -5,7 +5,7 @@
     <style>
         :root {
             --accent-color: {{ .Site.Params.AccentColor | default "#FF4D4D" }};
-            --font-size: {{ .Site.Params.FontSize | default "17.5px" }};
+            --font-size: {{ .Site.Params.FontSize | default "1.094rem" }};
         }
     </style>
 


### PR DESCRIPTION
improve accessibility by using (r)em units:

https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#pixels
https://fedmentor.dev/posts/font-size-px/