### PR TITLE
fix: prevent list page content links from losing underlines

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -511,7 +511,7 @@ table td {
 .list-posts .post-title {
   margin: 18px 0 0 15px;
 }
-.list-posts a {
+.list-posts .post-title a {
   text-decoration: none;
 }
 .post-title .post-link,


### PR DESCRIPTION
The overly broad `.list-posts a` selector was removing underlines from all links within list pages, including links in the page description. This change makes the selector more specific to only target post title links, allowing regular links to display with proper underline decoration.

# Solution
Changed the selector from `.list-posts a` to `.list-posts .post-title a` to specifically target only the post title links that should have no underline decoration.