### PR TITLE
Add RSS <link ...> to page <head> (and other alternative output formats)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,6 +50,10 @@
     {{ $jsBundle := resources.Match "js/**.js" | resources.Concat "js/bundle.js" | minify | resources.Fingerprint "sha256" }}
     <script src="{{ $jsBundle.RelPermalink }}" integrity="{{ $jsBundle.Data.Integrity }}"></script>
 
+    {{ range .AlternativeOutputFormats }}
+    {{ printf "<link rel=%q type=%q href=%q title=%q>" .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ end }}
+
     <!-- Option for user to inject custom html -->
     {{ if .Site.Params.CustomHeadHTML }}
     {{ .Site.Params.CustomHeadHTML | safeHTML }}


### PR DESCRIPTION
Gokarna already generates the RSS feed, but it doesn't link to it in HTML pages. This makes it harder for readers to discover/subscribe to the feed.

Example output (for https://moreati.org.uk/)

```html
<link rel="alternate" type="application/rss+xml"
 href="https://moreati.org.uk/index.xml" title="Misspelled Nemesis Club">
```